### PR TITLE
Potential fix for code scanning alert no. 6: Database query built from user-controlled sources

### DIFF
--- a/Controller/user.controller.js
+++ b/Controller/user.controller.js
@@ -1,4 +1,5 @@
 const model = require("../models/user.model");
+const sanitize = require("mongo-sanitize");
 const getUsers = async (req, res) => {
   try {
     const user = await model.find({});
@@ -20,10 +21,11 @@ const updateUser = async (req, res) => {
   try {
     const { id } = req.params;
     // Sanitize update payload: prevent injection of MongoDB operators
+    const sanitizedBody = sanitize(req.body || {});
     const updateData = {};
-    Object.keys(req.body || {}).forEach((key) => {
+    Object.keys(sanitizedBody).forEach((key) => {
       if (!key.startsWith("$")) {
-        updateData[key] = req.body[key];
+        updateData[key] = sanitizedBody[key];
       }
     });
     const user = await model.findByIdAndUpdate(id, updateData);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "^4.19.2",
     "mongodb": "^6.8.0",
     "mongoose": "^8.4.4",
-    "nodemon": "^3.1.4"
+    "nodemon": "^3.1.4",
+    "mongo-sanitize": "^1.1.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Subeen9/CRUDAPI/security/code-scanning/6](https://github.com/Subeen9/CRUDAPI/security/code-scanning/6)

Use a robust, library-backed sanitizer for MongoDB payloads before passing user input into Mongoose update APIs. The best fix here is to sanitize `req.body` with `mongo-sanitize` (or equivalent) and still enforce the top-level `$` key blocklist before calling `findByIdAndUpdate`.

In `Controller/user.controller.js`:
- Add `mongo-sanitize` import at the top.
- In `updateUser`, sanitize `req.body` first (`const sanitizedBody = sanitize(req.body || {});`).
- Build `updateData` from `sanitizedBody` (not raw `req.body`), keeping the existing `$` key rejection.
- Pass `updateData` to `findByIdAndUpdate` as before.

This preserves behavior (updates fields from request body) while removing dangerous operator payloads and reducing NoSQL injection risk in the update object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
